### PR TITLE
Added import for other base files: fonts, typography and helpers

### DIFF
--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "UTF-8";
 
 // 1. Vendors
 @import
@@ -12,7 +12,10 @@
 
 // 3. Base stuff
 @import
-  'base/base';
+  'base/base',
+  'base/fonts',
+  'base/typography',
+  'base/helpers';
 
 // 4. Layout-related sections
 @import

--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -1,4 +1,4 @@
-@charset "UTF-8";
+@charset 'UTF-8';
 
 // 1. Vendors
 @import


### PR DESCRIPTION
Fixed double quote required for `@charset` and added `@import` for other base files: _fonts, _typography and _helpers.