### PR TITLE
Fix initial lint errors

### DIFF
--- a/stylesheets/base/_base.scss
+++ b/stylesheets/base/_base.scss
@@ -15,9 +15,11 @@ html {
  * making all elements inheriting from the root box-sizing value
  * See: https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/
  */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: inherit;
-} 
+}
 
 /**
  * Basic styles for links

--- a/stylesheets/base/_helpers.scss
+++ b/stylesheets/base/_helpers.scss
@@ -43,7 +43,7 @@
  * Shamelessly borrowed from HTML5Boilerplate:
  * https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css#L119-L133
  */
-.visually-hidden { 
+.visually-hidden {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;


### PR DESCRIPTION
- Removed trailing whitespace after .visually-hidden class in base/_helpers
- Moved each box sizing selector in base/_base to its own line

These issues were causing lint errors.