### PR TITLE
Provide node-sass how-to section. Closes #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,28 @@ Each folder of this project has its own `README.md` file to explain the purpose 
 
 ## Using the indented syntax
 
+### Sass conversion
+
 This boilerplate does not provide a `.sass` version as it would be painful to maintain both versions without an appropriate build process. However, it is very easy to convert this boilerplate to Sass indented syntax.
 
 Clone it, head into the project and then run:
 
 ```
 sass-convert -F scss -T sass -i -R ./  && find . -iname “*.scss” -exec bash -c 'mv "$0" “${0%\.scss}.sass"' {} \;
+```
+
+### Use with Node-sass
+
+When using `node-sass` - in order to build that boilerplate, one needs to:
+
+- install `node-sass` if not yet installed:
+
+```bash
+npm install -g node-sass
+```
+
+- run build command from command line:
+
+```bash
+node-sass stylesheets/main.scss dist/main.css
 ```


### PR DESCRIPTION
The `Readme.md` update covers adding and running `node-sass` for those of use, who usually works with NodeJS based tooling.

Thanks!