### PR TITLE
Use double quotes for character encoding string

### DIFF
--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "UTF-8";
 
 // 1. Configuration and helpers
 @import


### PR DESCRIPTION
>[charset] must be […] double-quoted […].
> – [**@charset** MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/@charset#Syntax)